### PR TITLE
Support git submodules.

### DIFF
--- a/dp
+++ b/dp
@@ -193,7 +193,18 @@ rm -f \$DIST_DIR/../current
 ln -s \$DIST_DIR \$DIST_DIR/../current
 EOF
 )
-    git archive $branch . | runssh "$cmds"
+
+    # Git archive doesn't support submodules, so we re-implement ourselves.
+    # This works well, but sadly we loose support for the gitattributes
+    # 'export-ignore' attribute.
+    { git ls-files;
+      git submodule foreach --quiet --recursive \
+        'cd $toplevel; cd $name; 
+         git ls-files --with-tree="$sha1" | sed "s#^#$toplevel/$name/#"'
+    } \
+      | sed "s#$(pwd)/##" \
+      | xargs tar -c -f - --no-recursion -- \
+      | runssh "$cmds"
     ;;
   *)
     echo "Unknown command!"


### PR DESCRIPTION
Sadly git archive doesn't support submodules, so we implement it
ourselves using ls-files. This works well, but we do loose support for
the git attributes feature, 'export-ignore', which allows you to exclude
files from a git archive output. This seems like a better trade-off.