### PR TITLE
Logrotate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DP Changelog
 
+## Version 1.1.0 -- May 18th, 2016
+
+* Make use of `multilog` in daemontools to rotate logs.
+
 ## Version 1.0.1 -- April 5th, 2016
 
 * Avoid use of bash 4.0 syntax `;&` for switch fallthrough.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Think of it like a cheap and cheerful Heroku interface to your server
 for running and deploying simple applications. It requries that you
 are using git to manage your application.
 
+It also relies on `start-stop-daemon` for launching the daemon tools
+`supervise` process.
+
 ## Installation
     
     $ cp dp /usr/local/bin/dp
@@ -26,6 +29,11 @@ After that, edit the following files:
   * .dp/compile -- a simple shell script specifying how to compile
     your application to a runnable process. Executed on the remote
     server.
+
+You'll also need to edit `Procfile`, to set the name and way to launch your
+app. For example:
+
+        web: node app.js
 
 Once done, you should be able to type:
 

--- a/dp
+++ b/dp
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-DP_VERSION=1.0.1
+DP_VERSION=1.1.0
 
 set -e
 

--- a/dp
+++ b/dp
@@ -36,6 +36,8 @@ EOF
 PORT=22
 BASE_DIR="\$HOME/app"
 REMOTE_USER=${REMOTE_USER:-$(whoami)}
+LOG_FILES=10
+LOG_SIZE=10485760
 defaultenv="default"
 envdir=${ENV:-$defaultenv}
 
@@ -80,12 +82,18 @@ case "$command" in
 
 # Directory to install your app to (Default: \$HOME)
 #BASE_DIR=...
+
+# Log management (can't change after setting up server!)
+#LOG_FILES=${LOG_FILES}
+#LOG_SIZE=${LOG_SIZE}
 EOF
   cp .dp/production/config .dp/staging/config
   cat << EOF > .dp/compile
 # Place compilation commands here
 EOF
+    touch Procfile
     echo "Please edit .dp/*/config files now to setup the remote server"
+    echo "Please edit Procfile to set app command"
     exit
     ;;
 esac
@@ -123,15 +131,22 @@ case "$command" in
 mkdir -p $BASE_DIR/versions
 mkdir -p $BASE_DIR/.envdir
 touch $BASE_DIR/log
-cat <<EF > $BASE_DIR/run
+cat <<EF > $BASE_DIR/cmd
 #!/usr/bin/env bash
 cd \\\`dirname \\\$0\\\`/versions/current
 IFS="[: ]"
 read name cmd < Procfile
 echo "Starting \\\$name..."
-exec envdir ../../.envdir bash -c \"\\\$cmd\"
+exec envdir ../../.envdir bash -c "\\\$cmd"
+EF
+chmod +x $BASE_DIR/cmd
+cat <<EF > $BASE_DIR/run
+#!/usr/bin/env bash
+WHERE=\\\`pwd\\\`
+./cmd | multilog s${LOG_SIZE} n${LOG_FILES} \\\$WHERE/logs
 EF
 chmod +x $BASE_DIR/run
+ln -s $BASE_DIR/logs/current log
 EOF
 )
     runssh "$cmd"
@@ -187,7 +202,10 @@ EOF
 svok $BASE_DIR
 if [[ \$? -gt 0 ]]
 then
-  start-stop-daemon --no-close --background -m --pidfile $BASE_DIR/pid --start --startas \`which supervise\` -- $BASE_DIR &>> $BASE_DIR/log
+  start-stop-daemon --no-close --background -m \
+    --pidfile $BASE_DIR/pid --start \
+    --startas \`which supervise\` \
+    -- $BASE_DIR &>> $BASE_DIR/supervise.log
 else
   svc -u $BASE_DIR
 fi


### PR DESCRIPTION
To deploy this, it's easiest to split the `run` file into two, `cmd`, which does what `run` used to do, and `run` which just calls `cmd` but handles logging.