### PR TITLE
Allow user to deploy a tag

### DIFF
--- a/dp
+++ b/dp
@@ -298,7 +298,7 @@ EOF
 
   deploy)
     [[ $# -gt 0 ]] && branch=$1 || branch=master
-    githash=`git show-ref -s refs/heads/$branch`
+    githash=`git show-ref -s --tags --heads $branch`
     cmds=$(cat <<EOF
 set -e
 cat > /tmp/app.tar;


### PR DESCRIPTION
Fix #13 

Parses the argument to `deploy` as either a local branch or a tag.