### PR TITLE
Add support for apps in monorepo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # DP Changelog
 
+## Version 1.4.0 -- April 30th, 2017
+
+* Add new deployment style, `git`, that copies across the whole git repository.
+* Add support for `DEPLOY_MODE` to select between new `git` style and old `dir`
+  style.
+
 ## Version 1.3.1 -- February 22nd, 2017
 
 * Fix bug in `old` and `old:clean` commands detecting current deploy.

--- a/dp
+++ b/dp
@@ -114,6 +114,9 @@ case "$command" in
 # Log files (can't change after init-server)
 LOG_SIZE=10485760
 LOG_FILES=10
+
+# Deployment style (sub-directory [dir] or git-directory [git])
+#DEPLOY_MODE=dir
 EOF
   cp .dp/production/config .dp/staging/config
   cat << EOF > .dp/compile
@@ -134,6 +137,25 @@ else
   echo "No .dp/$envdir/ directory found"
   echo "Is this a DP managed app?"
   exit 1
+fi
+
+# Figure out deploy mode
+if [[ -z "$DEPLOY_MODE" ]]; then
+  DEPLOY_MODE=DIR
+fi
+
+DEPLOY_MODE=${DEPLOY_MODE^^} # convert to uppercase
+
+if [[ "$command" = "deploy" ]];
+then
+  if [[ "$DEPLOY_MODE" = "GIT" ]]; then
+    command=deploy-git
+  elif [[ "$DEPLOY_MODE" = "DIR" ]]; then
+    command=deploy-dir
+  else
+    echo "Unknown DEPLOY_MODE ($DEPLOY_MODE)!"
+    exit 1
+  fi
 fi
 
 # Sanity check args
@@ -296,7 +318,47 @@ EOF
     echo "done"
     ;;
 
-  deploy)
+  deploy-dir)
+    # deploy method that just copies from directory `.dp` is located in and
+    # down.
+    [[ $# -gt 0 ]] && branch=$1 || branch=master
+    githash=`git show-ref -s --tags --heads $branch`
+    cmds=$(cat <<EOF
+set -e
+cat > /tmp/app.tar;
+export APP_DIR=$APP_DIR
+export DIST_DIR=$APP_DIR/versions/\`date -u +%Y%m%d%H%M\`
+mkdir -p \$DIST_DIR
+echo "Extracting app"
+tar xf /tmp/app.tar -C \$DIST_DIR
+cd \$DIST_DIR
+echo $githash > .gitversion
+echo "Compiling..."
+
+`cat .dp/compile`
+
+rm -f \$DIST_DIR/../current
+ln -s \$DIST_DIR \$DIST_DIR/../current
+EOF
+)
+
+    # Git archive doesn't support submodules, so we re-implement ourselves.
+    # This works well, but sadly we loose support for the gitattributes
+    # 'export-ignore' attribute.
+    { git ls-files;
+      git submodule foreach --quiet --recursive \
+        'cd $toplevel; cd $name;
+         git ls-files --with-tree="$sha1" | sed "s#^#$toplevel/$name/#"'
+    } \
+      | sed "s#$(pwd)/##" \
+      | xargs tar -c -f - --no-recursion -- \
+      | runssh "$cmds"
+    ;;
+
+  deploy-git)
+    # deploy method that just copies across the whole git repo. Useful in a
+    # situation (such as a mono-repo) where a dp managed app has dependencies
+    # located outside the local root (e.g. `../dependency`).
     [[ $# -gt 0 ]] && branch=$1 || branch=master
     githash=`git show-ref -s --tags --heads $branch`
     appbase=`pwd`
@@ -390,7 +452,7 @@ EOF
     ;;
 
   *)
-    echo "Unknown command!"
+    echo "Unknown command! ($command)"
     exit 1
     ;;
 

--- a/dp
+++ b/dp
@@ -299,6 +299,16 @@ EOF
   deploy)
     [[ $# -gt 0 ]] && branch=$1 || branch=master
     githash=`git show-ref -s --tags --heads $branch`
+    appbase=`pwd`
+    while [ ! -d .git ]; do cd ..; done
+    repobase=`pwd`
+    apprel=`realpath --relative-to $repobase $appbase`
+    if [ $apprel = "." ]
+    then
+        procfilelink=""
+    else
+        procfilelink="ln -s \$DIST_DIR/$apprel/Procfile \$DIST_DIR/Procfile"
+    fi
     cmds=$(cat <<EOF
 set -e
 cat > /tmp/app.tar;
@@ -307,11 +317,12 @@ export DIST_DIR=$APP_DIR/versions/\`date -u +%Y%m%d%H%M\`
 mkdir -p \$DIST_DIR
 echo "Extracting app"
 tar xf /tmp/app.tar -C \$DIST_DIR
-cd \$DIST_DIR
+cd \$DIST_DIR/$apprel
 echo $githash > .gitversion
 echo "Compiling..."
 
-`cat .dp/compile`
+`cat $apprel/.dp/compile`
+$procfilelink
 
 rm -f \$DIST_DIR/../current
 ln -s \$DIST_DIR \$DIST_DIR/../current

--- a/dp
+++ b/dp
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-DP_VERSION=1.3.1
+DP_VERSION=1.4.0
 
 set -e
 


### PR DESCRIPTION
I've tested this out on staging2 and it seems to work.  If you do `dp deploy <branch>` in a directory without a `.git` directory, it just steps up the directory hierarchy until it finds a `.git`, uploads all of that stuff to the deployment machine, then uses the `.dp/compile` in the subdirectory where you started to do a build and makes a link in the base deployment directory to the `Procfile` in the subdirectory where you started.  That makes everything just work, as far as I can tell, at least in terms of `deploy` and `restart`.  If you don't like it, feel free to revert the relevant change and we can try something else.  I've also made a PR for using a single `stack.yaml` for `townhall`.  That also seems to work OK.

From Slack:

dterei [6:54 PM] 
I think my only issue (haven't looked yet, more a hunch) would be that we may want to make this new behavior and the old behavior selectable

ian-ross [7:36 PM] 
You get the same "old" behaviour in any case where you have a single `dp`-deployable app in a repo, i.e. in the case where you have a `.dp` and a `.git` in the same directory. The "new" behaviour only happens if you run `dp` from a sub-directory of a Git repo that has a `.dp` directory. I should test that that's really the case, but I think it's true. (I didn't intend to push this straight to master in the `dp` repository: I was trying to make a PR for discussion, but something went funny with it.)

dterei
[7:38 PM] 
Sure, I get that

[7:39] 
But I think there are situations where i have a subdirectory with `.dp` and a higher level directory with `.git` and want the old behavior

[7:39] 
Maybe less so for us, but we've been developing `dp` as a somewhat general tool beyond just us

[7:40] 
Even for us though, I'd probably set the go code to use the old behavior for example

ian-ross [7:40 PM] 
OK, didn't realise that. In that case we probably do want a flag to select between the two behaviours.