### PR TITLE
Totally change how "dp deploy" works...

### DIFF
--- a/dp
+++ b/dp
@@ -7,6 +7,10 @@ function runssh() {
   ssh -p $PORT $SSH_ARGS $REMOTE_USER@$REMOTE_HOST $2 "$1"
 }
 
+function runscp() {
+  scp -P $PORT $SSH_ARGS "$1" "$REMOTE_USER@$REMOTE_HOST:$2"
+}
+
 function print_usage() {
     cat <<EOF
 MemCachier Daemon Deployment Tool!
@@ -306,25 +310,29 @@ EOF
     repobase=`pwd`
     apprel=`realpath --relative-to $repobase $appbase`
     cd $appbase
-    githash=`git show-ref -s --tags --heads $branch`
     if [ $apprel = "." ]
     then
         procfilelink=""
     else
         procfilelink="ln -s \$DIST_DIR/$apprel/Procfile \$DIST_DIR/Procfile"
     fi
-    reponame=`git config --get remote.origin.url`
+    echo "SETTING UP REPO FOR VERSION: $branch..."
+    githash=`git show-ref -s --tags --heads $branch`
+    timestamp=`date -u +%Y%m%d%H%M`
+    git clone --local $repobase .dp/$timestamp
+    cd .dp/$timestamp
+    git submodule init
+    git -c advice.detachedHead=false checkout --detach $branch
+    git submodule update --recursive
+    cd ..
     cmds=$(cat <<EOF
 set -e
 export APP_DIR=$APP_DIR
-export DIST_DIR=$APP_DIR/versions/\`date -u +%Y%m%d%H%M\`
-echo "CLONING REPO..."
-GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone $reponame \$DIST_DIR
+export DIST_DIR=$APP_DIR/versions/$timestamp
+echo "EXTRACTING APP..."
+tar xzf /tmp/$timestamp.tar.gz -C \$APP_DIR/versions
+/bin/rm /tmp/$timestamp.tar.gz
 cd \$DIST_DIR
-echo "SETTING UP REPO FOR VERSION: $branch..."
-git submodule init
-git -c advice.detachedHead=false checkout --detach $branch
-git submodule update --recursive
 echo $githash > .gitversion
 cd \$DIST_DIR/$apprel
 echo "COMPILING..."
@@ -338,7 +346,12 @@ ln -s \$DIST_DIR/$apprel \$DIST_DIR/../current-appbase
 EOF
 )
 
+    echo "CREATING TARBALL..."
+    tar -cz -f ./$timestamp.tar.gz ./$timestamp
+    echo "UPLOADING TARBALL..."
+    runscp ./$timestamp.tar.gz /tmp
     runssh "$cmds"
+    /bin/rm -fr ./$timestamp ./$timestamp.tar.gz
     ;;
 
   ssh)

--- a/dp
+++ b/dp
@@ -114,9 +114,6 @@ case "$command" in
 # Log files (can't change after init-server)
 LOG_SIZE=10485760
 LOG_FILES=10
-
-# Deployment style (sub-directory [dir] or git-directory [git])
-#DEPLOY_MODE=dir
 EOF
   cp .dp/production/config .dp/staging/config
   cat << EOF > .dp/compile
@@ -137,25 +134,6 @@ else
   echo "No .dp/$envdir/ directory found"
   echo "Is this a DP managed app?"
   exit 1
-fi
-
-# Figure out deploy mode
-if [[ -z "$DEPLOY_MODE" ]]; then
-  DEPLOY_MODE=DIR
-fi
-
-DEPLOY_MODE=${DEPLOY_MODE^^} # convert to uppercase
-
-if [[ "$command" = "deploy" ]];
-then
-  if [[ "$DEPLOY_MODE" = "GIT" ]]; then
-    command=deploy-git
-  elif [[ "$DEPLOY_MODE" = "DIR" ]]; then
-    command=deploy-dir
-  else
-    echo "Unknown DEPLOY_MODE ($DEPLOY_MODE)!"
-    exit 1
-  fi
 fi
 
 # Sanity check args
@@ -318,77 +296,41 @@ EOF
     echo "done"
     ;;
 
-  deploy-dir)
-    # deploy method that just copies from directory `.dp` is located in and
-    # down.
-    [[ $# -gt 0 ]] && branch=$1 || branch=master
-    githash=`git show-ref -s --tags --heads $branch`
-    cmds=$(cat <<EOF
-set -e
-cat > /tmp/app.tar;
-export APP_DIR=$APP_DIR
-export DIST_DIR=$APP_DIR/versions/\`date -u +%Y%m%d%H%M\`
-mkdir -p \$DIST_DIR
-echo "Extracting app"
-tar xf /tmp/app.tar -C \$DIST_DIR
-cd \$DIST_DIR
-echo $githash > .gitversion
-echo "Compiling..."
-
-`cat .dp/compile`
-
-rm -f \$DIST_DIR/../current
-rm -f \$DIST_DIR/../current-appbase
-ln -s \$DIST_DIR \$DIST_DIR/../current
-ln -s \$DIST_DIR \$DIST_DIR/../current-appbase
-EOF
-)
-
-    # Git archive doesn't support submodules, so we re-implement ourselves.
-    # This works well, but sadly we loose support for the gitattributes
-    # 'export-ignore' attribute.
-    { git ls-files;
-      git submodule foreach --quiet --recursive \
-        'cd $toplevel; cd $name;
-         git ls-files --with-tree="$sha1" | sed "s#^#$toplevel/$name/#"'
-    } \
-      | sed "s#$(pwd)/##" \
-      | xargs tar -c -f - --no-recursion -- \
-      | runssh "$cmds"
-    ;;
-
-  deploy-git)
+  deploy)
     # deploy method that just copies across the whole git repo. Useful in a
     # situation (such as a mono-repo) where a dp managed app has dependencies
     # located outside the local root (e.g. `../dependency`).
     [[ $# -gt 0 ]] && branch=$1 || branch=master
-    githash=`git show-ref -s --tags --heads $branch`
     appbase=`pwd`
     while [ ! -d .git ]; do cd ..; done
     repobase=`pwd`
     apprel=`realpath --relative-to $repobase $appbase`
+    cd $appbase
+    githash=`git show-ref -s --tags --heads $branch`
     if [ $apprel = "." ]
     then
         procfilelink=""
     else
         procfilelink="ln -s \$DIST_DIR/$apprel/Procfile \$DIST_DIR/Procfile"
     fi
+    reponame=`git config --get remote.origin.url`
     cmds=$(cat <<EOF
 set -e
-cat > /tmp/app.tar;
 export APP_DIR=$APP_DIR
 export DIST_DIR=$APP_DIR/versions/\`date -u +%Y%m%d%H%M\`
-mkdir -p \$DIST_DIR
-echo "Extracting app"
-tar xf /tmp/app.tar -C \$DIST_DIR
+echo "CLONING REPO..."
+GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone $reponame \$DIST_DIR
 cd \$DIST_DIR
+echo "SETTING UP REPO FOR VERSION: $branch..."
+git submodule init
+git -c advice.detachedHead=false checkout --detach $branch
+git submodule update --recursive
 echo $githash > .gitversion
 cd \$DIST_DIR/$apprel
-echo "Compiling..."
-
-`cat $apprel/.dp/compile`
+echo "COMPILING..."
+. ./.dp/compile
 $procfilelink
-
+echo "UPDATING CURRENT VERSION LINK..."
 rm -f \$DIST_DIR/../current
 rm -f \$DIST_DIR/../current-appbase
 ln -s \$DIST_DIR \$DIST_DIR/../current
@@ -396,17 +338,7 @@ ln -s \$DIST_DIR/$apprel \$DIST_DIR/../current-appbase
 EOF
 )
 
-    # Git archive doesn't support submodules, so we re-implement ourselves.
-    # This works well, but sadly we loose support for the gitattributes
-    # 'export-ignore' attribute.
-    { git ls-files;
-      git submodule foreach --quiet --recursive \
-        'cd $toplevel; cd $name;
-         git ls-files --with-tree="$sha1" | sed "s#^#$toplevel/$name/#"'
-    } \
-      | sed "s#$(pwd)/##" \
-      | xargs tar -c -f - --no-recursion -- \
-      | runssh "$cmds"
+    runssh "$cmds"
     ;;
 
   ssh)


### PR DESCRIPTION
Before this commit, `dp` created a deployment tarball from the **current working directory**, irrespective of what branch you told it to deploy, and irrespective of any uncommitted or even unstaged changes in the working directory.  This commit attempts to make the behaviour of `dp deploy` a little more sane.

The new `dp deploy` does the following:

- Clones the Git repository where `dp deploy` is run on the remote machine.  The clone appears in the `versions/<date>` directory for the application being deployed.  (The remote machine thus needs to have the appropriate SSH keys in place to allow this to work.)

- Sets up Git submodules and checks out the requested branch.

- Uses the `.dp/compile` script to build the application.

- Creates symbolic links as required.

This procedure means that the deployments ALWAYS happen from a well-defined branch in the Git repository.