### PR TITLE
VM builds

### DIFF
--- a/dp
+++ b/dp
@@ -11,6 +11,126 @@ function runscp() {
   scp -P $PORT $SSH_ARGS "$1" "$REMOTE_USER@$REMOTE_HOST:$2"
 }
 
+function basic_deploy() {
+    appbase=$1
+    repobase=$2
+    apprel=$3
+    timestamp=$4
+    githash=$5
+
+    git clone --local $repobase .dp/$timestamp
+    cd .dp/$timestamp
+    git submodule init
+    git -c advice.detachedHead=false checkout $branch
+    git submodule update --recursive
+
+    if [ $apprel = "." ]
+    then
+        procfilelink=""
+    else
+        procfilelink="ln -s \$DIST_DIR/$apprel/Procfile \$DIST_DIR/Procfile"
+    fi
+
+    cmds=$(cat <<EOF
+set -e
+export APP_DIR=$APP_DIR
+export DIST_DIR=$APP_DIR/versions/$timestamp
+echo EXTRACTING APP...
+tar xzf /tmp/$timestamp.tar.gz -C \$APP_DIR/versions
+/bin/rm /tmp/$timestamp.tar.gz
+cd \$DIST_DIR
+echo $githash > .gitversion
+cd \$DIST_DIR/$apprel
+echo COMPILING...
+. ./.dp/compile
+$procfilelink
+echo UPDATING CURRENT VERSION LINK...
+rm -f \$DIST_DIR/../current
+rm -f \$DIST_DIR/../current-appbase
+ln -s \$DIST_DIR \$DIST_DIR/../current
+ln -s \$DIST_DIR/$apprel \$DIST_DIR/../current-appbase
+EOF
+)
+
+    echo "CREATING TARBALL..."
+    tar -cz -f ./$timestamp.tar.gz ./$timestamp
+    echo "UPLOADING TARBALL..."
+    runscp ./$timestamp.tar.gz /tmp
+    runssh "$cmds"
+    /bin/rm -fr ./$timestamp ./$timestamp.tar.gz
+}
+
+function vm_deploy() {
+    appbase=$1
+    repobase=$2
+    apprel=$3
+    timestamp=$4
+    githash=$5
+
+    # Clone the local repository into a new build directory, reusing
+    # the .stack-work directory in any currently existing build
+    # directory.
+    if [ -d $repobase/.dp-vm-build ]
+    then
+        git clone --local $repobase $repobase/.dp-vm-build-tmp
+        mv $repobase/.dp-vm-build/.stack-work $repobase/.dp-vm-build-tmp
+        /bin/rm -fr $repobase/.dp-vm-build
+        mv $repobase/.dp-vm-build-tmp $repobase/.dp-vm-build
+    else
+        git clone --local $repobase $repobase/.dp-vm-build
+    fi
+
+    # Set up Git version to build.
+    cd $repobase/.dp-vm-build
+    git submodule init
+    git -c advice.detachedHead=false checkout $branch
+    git submodule update --recursive
+
+    # Need to remove the Vagrantfile from the build directory,
+    # otherwise Vagrant gets confused about which VM to use.
+    /bin/rm -f $repobase/.dp-vm-build/Vagrantfile
+
+    # Run build process in VM, extracting build artefacts.
+    echo "BUILDING IN VM..."
+    cd $repobase
+    artefact_dir=/vagrant/$apprel/.dp/$timestamp
+    echo "
+set -e
+cd /vagrant/.dp-vm-build/$apprel
+echo COMPILING...
+. .dp/compile
+mkdir -p $artefact_dir
+. .dp/extract $artefact_dir
+echo $githash > $artefact_dir/.gitversion
+" | vagrant ssh
+
+    # Deploy process is similar to "normal" build.
+    deploy_cmds=$(cat <<EOF
+set -e
+export APP_DIR=$APP_DIR
+export DIST_DIR=$APP_DIR/versions/$timestamp
+echo EXTRACTING APP...
+tar xzf /tmp/$timestamp.tar.gz -C \$APP_DIR/versions
+/bin/rm /tmp/$timestamp.tar.gz
+cd \$DIST_DIR
+echo UPDATING CURRENT VERSION LINK...
+rm -f \$DIST_DIR/../current
+rm -f \$DIST_DIR/../current-appbase
+ln -s \$DIST_DIR \$DIST_DIR/../current
+EOF
+)
+
+    # Create and upload deployment tarball and run deployment script
+    # on target machine.
+    echo "CREATING TARBALL..."
+    cd $appbase/.dp
+    tar -cz -f ./$timestamp.tar.gz ./$timestamp
+    echo "UPLOADING TARBALL..."
+    runscp ./$timestamp.tar.gz /tmp
+    runssh "$deploy_cmds"
+    /bin/rm -fr ./$timestamp ./$timestamp.tar.gz
+}
+
 function print_usage() {
     cat <<EOF
 MemCachier Daemon Deployment Tool!
@@ -301,57 +421,27 @@ EOF
     ;;
 
   deploy)
-    # deploy method that just copies across the whole git repo. Useful in a
-    # situation (such as a mono-repo) where a dp managed app has dependencies
-    # located outside the local root (e.g. `../dependency`).
     [[ $# -gt 0 ]] && branch=$1 || branch=master
     appbase=`pwd`
     while [ ! -d .git ]; do cd ..; done
     repobase=`pwd`
     apprel=`realpath --relative-to $repobase $appbase`
     cd $appbase
-    if [ $apprel = "." ]
-    then
-        procfilelink=""
-    else
-        procfilelink="ln -s \$DIST_DIR/$apprel/Procfile \$DIST_DIR/Procfile"
-    fi
     echo "SETTING UP REPO FOR VERSION: $branch..."
-    githash=`git show-ref -s --tags --heads $branch`
+    if git show-ref -s --tags --heads $branch
+    then
+        githash=`git show-ref -s --tags --heads $branch`
+    else
+        echo "UNKNOWN VERSION: $branch!"
+        exit 1
+    fi
     timestamp=`date -u +%Y%m%d%H%M`
-    git clone --local $repobase .dp/$timestamp
-    cd .dp/$timestamp
-    git submodule init
-    git -c advice.detachedHead=false checkout --detach $branch
-    git submodule update --recursive
-    cd ..
-    cmds=$(cat <<EOF
-set -e
-export APP_DIR=$APP_DIR
-export DIST_DIR=$APP_DIR/versions/$timestamp
-echo "EXTRACTING APP..."
-tar xzf /tmp/$timestamp.tar.gz -C \$APP_DIR/versions
-/bin/rm /tmp/$timestamp.tar.gz
-cd \$DIST_DIR
-echo $githash > .gitversion
-cd \$DIST_DIR/$apprel
-echo "COMPILING..."
-. ./.dp/compile
-$procfilelink
-echo "UPDATING CURRENT VERSION LINK..."
-rm -f \$DIST_DIR/../current
-rm -f \$DIST_DIR/../current-appbase
-ln -s \$DIST_DIR \$DIST_DIR/../current
-ln -s \$DIST_DIR/$apprel \$DIST_DIR/../current-appbase
-EOF
-)
-
-    echo "CREATING TARBALL..."
-    tar -cz -f ./$timestamp.tar.gz ./$timestamp
-    echo "UPLOADING TARBALL..."
-    runscp ./$timestamp.tar.gz /tmp
-    runssh "$cmds"
-    /bin/rm -fr ./$timestamp ./$timestamp.tar.gz
+    if [ "$DP_VM_BUILD" == "true" ]
+    then
+        vm_deploy $appbase $repobase $apprel $timestamp $githash
+    else
+        basic_deploy $appbase $repobase $apprel $timestamp $githash
+    fi
     ;;
 
   ssh)


### PR DESCRIPTION
If the `DP_VM_BUILDS` environment variable is set to `true`, builds for `dp deploy` will be performed within a Vagrant virtual machine instead of on the target machine.  Build artefacts to generate the upload tarball will be collected using an `extract` script that should be in the `.dp` directory alongside the `compile` script.

Builds within the VM are all performed in the `/vagrant/.dp-vm-build` directory: this ensures maximal sharing of precompiled packages between builds by Stack.
